### PR TITLE
Fix IndexOutOfBoundsException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+.gradle/
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Freenet plugin Keep Alive
+
+#### For building run
+```gradle jar```

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,34 @@
+apply plugin: 'java'
+
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile files('../fred/build/libs/freenet.jar')
+    compile group: 'org.apache.ant', name: 'ant', version: '1.10.5'
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir 'src/'
+        }
+    }
+}
+
+jar {
+    manifest {
+        attributes(
+                'Plugin-Main-Class': 'keepalive.Plugin')
+    }
+}
+
+processResources {
+    from ('src/keepalive/html/') {
+        into 'keepalive/html'
+    }
+}

--- a/manifest.mf
+++ b/manifest.mf
@@ -1,2 +1,0 @@
-Manifest-Version: 1.0
-Plugin-Main-Class: keepalive.Plugin

--- a/src/keepalive/Reinserter.java
+++ b/src/keepalive/Reinserter.java
@@ -507,7 +507,7 @@ public class Reinserter extends Thread {
 			}
 
 			// wait for finishing top block, if it was fetched.
-			if (vSegments.get(0) != null) {
+			if (!vSegments.isEmpty() && vSegments.get(0) != null) {
 				while (!(vSegments.get(0).isFinished())) {
 					synchronized (this) {
 						this.wait(1000);


### PR DESCRIPTION
IndexOutOfBoundsException has been happening In Reinserter L510. As a result KeepAlive plugin stopped working (was hanging) on the current address and didn't switch to the next one.